### PR TITLE
Fix: Multiple IncludeLaunchDescription

### DIFF
--- a/launch/receiver.launch.py
+++ b/launch/receiver.launch.py
@@ -70,8 +70,8 @@ def launch_setup(context, *args, **kwargs):
 
     # Wait for interface to be up
     wait_for_can_interface_proc = ExecuteProcess(
-        cmd=[['until ', FindExecutable(name='ip'), ' link show ', interface.perform(context), ' | ',
-              FindExecutable(name='grep'), ' \"state UP\"', '; do sleep 1; done']],
+        cmd=[['until ', FindExecutable(name='ip'), ' link show ', interface.perform(context),
+              ' | ', FindExecutable(name='grep'), ' \"state UP\"', '; do sleep 1; done']],
         shell=True
     )
 
@@ -120,6 +120,7 @@ def launch_setup(context, *args, **kwargs):
         configure_event,
         activate_event
     ]
+
 
 def generate_launch_description():
     arg_namespace = DeclareLaunchArgument(
@@ -171,4 +172,3 @@ def generate_launch_description():
     ld.add_action(arg_from_can_bus_topic)
     ld.add_action(OpaqueFunction(function=launch_setup))
     return ld
-

--- a/launch/receiver.launch.py
+++ b/launch/receiver.launch.py
@@ -60,10 +60,10 @@ def launch_setup(context, *args, **kwargs):
         namespace=namespace,
         parameters=[{
             'interface': interface.perform(context),
-            'enable_can_fd': enable_can_fd.perform(context),
-            'interval_sec': interval_sec.perform(context),
+            'enable_can_fd': enable_can_fd.perform(context) == 'true',
+            'interval_sec': float(interval_sec.perform(context)),
             'filters': filters.perform(context),
-            'use_bus_time': use_bus_time.perform(context),
+            'use_bus_time': use_bus_time.perform(context) == 'true',
         }],
         remappings=[('from_can_bus', from_can_bus_topic.perform(context))],
         output='screen')

--- a/launch/receiver.launch.py
+++ b/launch/receiver.launch.py
@@ -30,6 +30,7 @@ from launch.actions import (
     DeclareLaunchArgument,
     EmitEvent,
     ExecuteProcess,
+    OpaqueFunction,
     RegisterEventHandler)
 from launch.conditions import IfCondition
 from launch.event_handlers import OnProcessExit, OnProcessStart
@@ -55,21 +56,21 @@ def launch_setup(context, *args, **kwargs):
     node = LifecycleNode(
         package='ros2_socketcan',
         executable='socket_can_receiver_node_exe',
-        name=[interface, '_socket_can_receiver'],
+        name=f'{interface.perform(context)}_socket_can_receiver',
         namespace=namespace,
         parameters=[{
-            'interface': interface,
-            'enable_can_fd': enable_can_fd,
-            'interval_sec': interval_sec,
-            'filters': filters,
-            'use_bus_time': use_bus_time,
+            'interface': interface.perform(context),
+            'enable_can_fd': enable_can_fd.perform(context),
+            'interval_sec': interval_sec.perform(context),
+            'filters': filters.perform(context),
+            'use_bus_time': use_bus_time.perform(context),
         }],
-        remappings=[('from_can_bus', from_can_bus_topic)],
+        remappings=[('from_can_bus', from_can_bus_topic.perform(context))],
         output='screen')
 
     # Wait for interface to be up
     wait_for_can_interface_proc = ExecuteProcess(
-        cmd=[['until ', FindExecutable(name='ip'), ' link show ', interface, ' | ',
+        cmd=[['until ', FindExecutable(name='ip'), ' link show ', interface.perform(context), ' | ',
               FindExecutable(name='grep'), ' \"state UP\"', '; do sleep 1; done']],
         shell=True
     )

--- a/launch/receiver.launch.py
+++ b/launch/receiver.launch.py
@@ -41,7 +41,7 @@ from launch_ros.events.lifecycle import ChangeState
 from lifecycle_msgs.msg import Transition
 
 
-def generate_launch_description():
+def launch_setup(context, *args, **kwargs):
     namespace = LaunchConfiguration('namespace')
     interface = LaunchConfiguration('interface')
     enable_can_fd = LaunchConfiguration('enable_can_fd')
@@ -51,42 +51,6 @@ def generate_launch_description():
     auto_configure = LaunchConfiguration('auto_configure')
     auto_activate = LaunchConfiguration('auto_activate')
     from_can_bus_topic = LaunchConfiguration('from_can_bus_topic')
-
-    arg_namespace = DeclareLaunchArgument(
-      'namespace',
-      default_value='')
-
-    arg_interface = DeclareLaunchArgument(
-      'interface',
-      default_value='can0')
-
-    arg_enable_can_fd = DeclareLaunchArgument(
-      'enable_can_fd',
-      default_value='false')
-
-    arg_interval_sec = DeclareLaunchArgument(
-      'interval_sec',
-      default_value='1.0')
-
-    arg_use_bus_time = DeclareLaunchArgument(
-        'use_bus_time',
-        default_value='false')
-
-    arg_filters = DeclareLaunchArgument(
-        'filters',
-        default_value='0:0')
-
-    arg_auto_configure = DeclareLaunchArgument(
-      'auto_configure',
-      default_value='true')
-
-    arg_auto_activate = DeclareLaunchArgument(
-      'auto_activate',
-      default_value='true')
-
-    arg_from_can_bus_topic = DeclareLaunchArgument(
-      'from_can_bus_topic',
-      default_value='rx')
 
     node = LifecycleNode(
         package='ros2_socketcan',
@@ -149,7 +113,52 @@ def generate_launch_description():
         condition=IfCondition(auto_activate),
     )
 
+    return [
+        wait_for_can_interface_proc,
+        launch_node,
+        configure_event,
+        activate_event
+    ]
+
+def generate_launch_description():
+    arg_namespace = DeclareLaunchArgument(
+      'namespace',
+      default_value='')
+
+    arg_interface = DeclareLaunchArgument(
+      'interface',
+      default_value='can0')
+
+    arg_enable_can_fd = DeclareLaunchArgument(
+      'enable_can_fd',
+      default_value='false')
+
+    arg_interval_sec = DeclareLaunchArgument(
+      'interval_sec',
+      default_value='1.0')
+
+    arg_use_bus_time = DeclareLaunchArgument(
+        'use_bus_time',
+        default_value='false')
+
+    arg_filters = DeclareLaunchArgument(
+        'filters',
+        default_value='0:0')
+
+    arg_auto_configure = DeclareLaunchArgument(
+      'auto_configure',
+      default_value='true')
+
+    arg_auto_activate = DeclareLaunchArgument(
+      'auto_activate',
+      default_value='true')
+
+    arg_from_can_bus_topic = DeclareLaunchArgument(
+      'from_can_bus_topic',
+      default_value='rx')
+
     ld = LaunchDescription()
+
     ld.add_action(arg_namespace)
     ld.add_action(arg_interface)
     ld.add_action(arg_enable_can_fd)
@@ -159,8 +168,6 @@ def generate_launch_description():
     ld.add_action(arg_auto_configure)
     ld.add_action(arg_auto_activate)
     ld.add_action(arg_from_can_bus_topic)
-    ld.add_action(wait_for_can_interface_proc)
-    ld.add_action(launch_node)
-    ld.add_action(configure_event)
-    ld.add_action(activate_event)
+    ld.add_action(OpaqueFunction(function=launch_setup))
     return ld
+

--- a/launch/sender.launch.py
+++ b/launch/sender.launch.py
@@ -66,8 +66,8 @@ def launch_setup(context, *args, **kwargs):
 
     # Wait for interface to be up
     wait_for_can_interface_proc = ExecuteProcess(
-        cmd=[['until ', FindExecutable(name='ip'), ' link show ', interface.perform(context), ' | ',
-              FindExecutable(name='grep'), ' \"state UP\"', '; do sleep 1; done']],
+        cmd=[['until ', FindExecutable(name='ip'), ' link show ', interface.perform(context),
+              ' | ', FindExecutable(name='grep'), ' \"state UP\"', '; do sleep 1; done']],
         shell=True
     )
 
@@ -116,6 +116,7 @@ def launch_setup(context, *args, **kwargs):
         configure_event,
         activate_event,
     ]
+
 
 def generate_launch_description():
     arg_namespace = DeclareLaunchArgument(

--- a/launch/sender.launch.py
+++ b/launch/sender.launch.py
@@ -30,6 +30,7 @@ from launch.actions import (
     DeclareLaunchArgument,
     EmitEvent,
     ExecuteProcess,
+    OpaqueFunction,
     RegisterEventHandler)
 from launch.conditions import IfCondition
 from launch.event_handlers import OnProcessExit, OnProcessStart
@@ -41,7 +42,7 @@ from launch_ros.events.lifecycle import ChangeState
 from lifecycle_msgs.msg import Transition
 
 
-def generate_launch_description():
+def launch_setup(context, *args, **kwargs):
     namespace = LaunchConfiguration('namespace')
     interface = LaunchConfiguration('interface')
     enable_can_fd = LaunchConfiguration('enable_can_fd')
@@ -50,50 +51,22 @@ def generate_launch_description():
     auto_activate = LaunchConfiguration('auto_activate')
     to_can_bus_topic = LaunchConfiguration('to_can_bus_topic')
 
-    arg_namespace = DeclareLaunchArgument(
-      'namespace',
-      default_value='')
-
-    arg_interface = DeclareLaunchArgument(
-      'interface',
-      default_value='can0')
-
-    arg_enable_can_fd = DeclareLaunchArgument(
-      'enable_can_fd',
-      default_value='false')
-
-    arg_timeout_sec = DeclareLaunchArgument(
-      'timeout_sec',
-      default_value='1.0')
-
-    arg_auto_configure = DeclareLaunchArgument(
-      'auto_configure',
-      default_value='true')
-
-    arg_auto_activate = DeclareLaunchArgument(
-      'auto_activate',
-      default_value='true')
-
-    arg_to_can_bus_topic = DeclareLaunchArgument(
-      'to_can_bus_topic',
-      default_value='tx')
-
     node = LifecycleNode(
         package='ros2_socketcan',
         executable='socket_can_sender_node_exe',
-        name=[interface, '_socket_can_sender'],
+        name=f'{interface.perform(context)}_socket_can_sender',
         namespace=namespace,
         parameters=[{
-            'interface': interface,
-            'enable_can_fd': enable_can_fd,
-            'timeout_sec': timeout_sec,
+            'interface': interface.perform(context),
+            'enable_can_fd': enable_can_fd.perform(context) == 'true',
+            'timeout_sec': float(timeout_sec.perform(context)),
         }],
-        remappings=[('to_can_bus', to_can_bus_topic)],
+        remappings=[('to_can_bus', to_can_bus_topic.perform(context))],
         output='screen')
 
     # Wait for interface to be up
     wait_for_can_interface_proc = ExecuteProcess(
-        cmd=[['until ', FindExecutable(name='ip'), ' link show ', interface, ' | ',
+        cmd=[['until ', FindExecutable(name='ip'), ' link show ', interface.perform(context), ' | ',
               FindExecutable(name='grep'), ' \"state UP\"', '; do sleep 1; done']],
         shell=True
     )
@@ -137,6 +110,42 @@ def generate_launch_description():
         condition=IfCondition(auto_activate),
     )
 
+    return [
+        wait_for_can_interface_proc,
+        launch_node,
+        configure_event,
+        activate_event,
+    ]
+
+def generate_launch_description():
+    arg_namespace = DeclareLaunchArgument(
+      'namespace',
+      default_value='')
+
+    arg_interface = DeclareLaunchArgument(
+      'interface',
+      default_value='can0')
+
+    arg_enable_can_fd = DeclareLaunchArgument(
+      'enable_can_fd',
+      default_value='false')
+
+    arg_timeout_sec = DeclareLaunchArgument(
+      'timeout_sec',
+      default_value='1.0')
+
+    arg_auto_configure = DeclareLaunchArgument(
+      'auto_configure',
+      default_value='true')
+
+    arg_auto_activate = DeclareLaunchArgument(
+      'auto_activate',
+      default_value='true')
+
+    arg_to_can_bus_topic = DeclareLaunchArgument(
+      'to_can_bus_topic',
+      default_value='tx')
+
     ld = LaunchDescription()
     ld.add_action(arg_namespace)
     ld.add_action(arg_interface)
@@ -145,8 +154,5 @@ def generate_launch_description():
     ld.add_action(arg_auto_configure)
     ld.add_action(arg_auto_activate)
     ld.add_action(arg_to_can_bus_topic)
-    ld.add_action(wait_for_can_interface_proc)
-    ld.add_action(launch_node)
-    ld.add_action(configure_event)
-    ld.add_action(activate_event)
+    ld.add_action(OpaqueFunction(function=launch_setup))
     return ld


### PR DESCRIPTION
If multiple instances of the launch file are included using the `IncludeLaunchDescription`, their `LaunchConfiguration` will be shared. Therefore, arguments loaded last will overwrite all `LaunchConfiguration` with the same name. This prevents multiple nodes with different arguments to be launched, instead causing duplicate nodes to be created. 

By using the `OpaqueFunction` and retrieving the context of each `LaunchConfiguration`, the arguments are parsed successively and do not clobber. 