### PR TITLE
Fix: Use script instead of OpaqueFunction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,12 @@ install(
   RUNTIME DESTINATION bin
 )
 
+install(
+  PROGRAMS
+  scripts/activate_lifecycle
+  DESTINATION lib/${PROJECT_NAME}
+)
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   list(APPEND AMENT_LINT_AUTO_EXCLUDE

--- a/launch/receiver.launch.py
+++ b/launch/receiver.launch.py
@@ -26,9 +26,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import argparse
-import time
-
 from launch import LaunchDescription
 from launch.actions import (
     DeclareLaunchArgument,
@@ -37,65 +34,7 @@ from launch.actions import (
     RegisterEventHandler)
 from launch.event_handlers import OnProcessExit, OnProcessStart
 from launch.substitutions import FindExecutable, LaunchConfiguration
-from launch_ros.actions import LifecycleNode
-from lifecycle_msgs.msg import Transition
-import lifecycle_msgs.srv
-import rclpy
-
-
-def activate_lifecycle_node(context, *args, **kwargs):
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--namespace', type=str)
-    parser.add_argument('--interface', type=str)
-    parser.add_argument('--auto_configure', type=bool)
-    parser.add_argument('--auto_activate', type=bool)
-    parser.add_argument('--timeout', type=float)
-    parser.add_argument('--transition_attempts', type=int)
-    arg = parser.parse_args(args=args)
-
-    rclpy.init()
-    node = rclpy.create_node(f'{arg.interface}_socket_can_receiver_activator')
-
-    cli = node.create_client(
-        lifecycle_msgs.srv.ChangeState,
-        f'{arg.namespace}/'
-        f'{arg.interface}_socket_can_receiver/change_state')
-    if not cli.wait_for_service(timeout_sec=arg.timeout):
-        node.get_logger().error('Lifecycle service not available.')
-        return
-
-    retry_count = int(arg.transition_attempts)
-    req = lifecycle_msgs.srv.ChangeState.Request()
-
-    if arg.auto_configure:
-        req.transition.id = Transition.TRANSITION_CONFIGURE
-        for i in range(retry_count):
-            future = cli.call_async(req)
-            rclpy.spin_until_future_complete(node, future)
-            if future.result() and future.result().success:
-                node.get_logger().info('Lifecycle node configured successfully.')
-                break
-            else:
-                node.get_logger().warn(f'Activation attempt {i+1} failed. Retrying...')
-                time.sleep(arg.timeout)
-
-    if arg.auto_activate:
-        req.transition.id = Transition.TRANSITION_ACTIVATE
-        for i in range(retry_count):
-            future = cli.call_async(req)
-            rclpy.spin_until_future_complete(node, future)
-            if future.result() and future.result().success:
-                node.get_logger().info('Lifecycle node activated successfully.')
-                break
-            else:
-                node.get_logger().warn(f'Activation attempt {i+1} failed. Retrying...')
-                time.sleep(arg.timeout)
-
-    node.destroy_node()
-    rclpy.shutdown()
-
-    return []
-
+from launch_ros.actions import LifecycleNode, Node
 
 def launch_setup(context, *args, **kwargs):
     # Apply context and type cast all LaunchConfiguration
@@ -132,11 +71,13 @@ def launch_setup(context, *args, **kwargs):
     transition_attempts = int(
         LaunchConfiguration('transition_attempts').perform(context))
 
+    name = f'{interface}_socket_can_receiver'
+
     # SocketCAN receiver node
     node = LifecycleNode(
         package='ros2_socketcan',
         executable='socket_can_receiver_node_exe',
-        name=f'{interface}_socket_can_receiver',
+        name=name,
         namespace=namespace,
         parameters=[{
             'interface': interface,
@@ -163,23 +104,27 @@ def launch_setup(context, *args, **kwargs):
         )
     )
 
+    # Activate launch
+    activate_lifecycle_node = Node(
+        name=f'activate_{name}',
+        package='clearpath_ros2_socketcan_interface',
+        executable='activate_lifecycle',
+        namespace=namespace,
+        arguments=[
+            '--namespace', str(namespace),
+            '--node', str(name),
+            '--auto_configure', str(auto_configure),
+            '--auto_activate', str(auto_activate),
+            '--timeout', str(timeout),
+            '--transition_attempts', str(transition_attempts)
+        ]
+    )
+
     # Event to configure and activate node once node is up
     configure_event = RegisterEventHandler(
         event_handler=OnProcessStart(
             target_action=node,
-            on_start=[
-                OpaqueFunction(
-                    function=activate_lifecycle_node,
-                    args=[
-                        '--namespace', str(namespace),
-                        '--interface', str(interface),
-                        '--auto_configure', str(auto_configure),
-                        '--auto_activate', str(auto_activate),
-                        '--timeout', str(timeout),
-                        '--transition_attempts', str(transition_attempts)
-                    ]
-                )
-            ],
+            on_start=[activate_lifecycle_node],
         ),
     )
 

--- a/launch/receiver.launch.py
+++ b/launch/receiver.launch.py
@@ -36,6 +36,7 @@ from launch.event_handlers import OnProcessExit, OnProcessStart
 from launch.substitutions import FindExecutable, LaunchConfiguration
 from launch_ros.actions import LifecycleNode, Node
 
+
 def launch_setup(context, *args, **kwargs):
     # Apply context and type cast all LaunchConfiguration
     namespace = str(

--- a/launch/sender.launch.py
+++ b/launch/sender.launch.py
@@ -26,9 +26,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import argparse
-import time
-
 from launch import LaunchDescription
 from launch.actions import (
     DeclareLaunchArgument,
@@ -37,65 +34,7 @@ from launch.actions import (
     RegisterEventHandler)
 from launch.event_handlers import OnProcessExit, OnProcessStart
 from launch.substitutions import FindExecutable, LaunchConfiguration
-from launch_ros.actions import LifecycleNode
-from lifecycle_msgs.msg import Transition
-import lifecycle_msgs.srv
-import rclpy
-
-
-def activate_lifecycle_node(context, *args, **kwargs):
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--namespace', type=str)
-    parser.add_argument('--interface', type=str)
-    parser.add_argument('--auto_configure', type=bool)
-    parser.add_argument('--auto_activate', type=bool)
-    parser.add_argument('--timeout', type=float)
-    parser.add_argument('--transition_attempts', type=int)
-    arg = parser.parse_args(args=args)
-
-    rclpy.init()
-    node = rclpy.create_node(f'{arg.interface}_socket_can_sender_activator')
-
-    cli = node.create_client(
-        lifecycle_msgs.srv.ChangeState,
-        f'{arg.namespace}/'
-        f'{arg.interface}_socket_can_sender/change_state')
-    if not cli.wait_for_service(timeout_sec=arg.timeout):
-        node.get_logger().error('Lifecycle service not available.')
-        return
-
-    retry_count = int(arg.transition_attempts)
-    req = lifecycle_msgs.srv.ChangeState.Request()
-
-    if arg.auto_configure:
-        req.transition.id = Transition.TRANSITION_CONFIGURE
-        for i in range(retry_count):
-            future = cli.call_async(req)
-            rclpy.spin_until_future_complete(node, future)
-            if future.result() and future.result().success:
-                node.get_logger().info('Lifecycle node configured successfully.')
-                break
-            else:
-                node.get_logger().warn(f'Activation attempt {i+1} failed. Retrying...')
-                time.sleep(arg.timeout)
-
-    if arg.auto_activate:
-        req.transition.id = Transition.TRANSITION_ACTIVATE
-        for i in range(retry_count):
-            future = cli.call_async(req)
-            rclpy.spin_until_future_complete(node, future)
-            if future.result() and future.result().success:
-                node.get_logger().info('Lifecycle node activated successfully.')
-                break
-            else:
-                node.get_logger().warn(f'Activation attempt {i+1} failed. Retrying...')
-                time.sleep(arg.timeout)
-
-    node.destroy_node()
-    rclpy.shutdown()
-
-    return []
-
+from launch_ros.actions import LifecycleNode, Node
 
 def launch_setup(context, *args, **kwargs):
     # Apply context and type cast all LaunchConfiguration
@@ -126,11 +65,13 @@ def launch_setup(context, *args, **kwargs):
     transition_attempts = int(
         LaunchConfiguration('transition_attempts').perform(context))
 
+    name = f'{interface}_socket_can_sender'
+
     # SocketCAN sender node
     node = LifecycleNode(
         package='ros2_socketcan',
         executable='socket_can_sender_node_exe',
-        name=f'{interface}_socket_can_sender',
+        name=name,
         namespace=namespace,
         parameters=[{
             'interface': interface,
@@ -155,23 +96,27 @@ def launch_setup(context, *args, **kwargs):
         )
     )
 
+    # Activate launch
+    activate_lifecycle_node = Node(
+        name=f'activate_{name}',
+        package='clearpath_ros2_socketcan_interface',
+        executable='activate_lifecycle',
+        namespace=namespace,
+        arguments=[
+            '--namespace', str(namespace),
+            '--node', str(name),
+            '--auto_configure', str(auto_configure),
+            '--auto_activate', str(auto_activate),
+            '--timeout', str(timeout),
+            '--transition_attempts', str(transition_attempts)
+        ]
+    )
+
     # Event to configure and activate node once node is up
     configure_event = RegisterEventHandler(
         event_handler=OnProcessStart(
             target_action=node,
-            on_start=[
-              OpaqueFunction(
-                  function=activate_lifecycle_node,
-                  args=[
-                        '--namespace', str(namespace),
-                        '--interface', str(interface),
-                        '--auto_configure', str(auto_configure),
-                        '--auto_activate', str(auto_activate),
-                        '--timeout', str(timeout),
-                        '--transition_attempts', str(transition_attempts)
-                  ]
-              )
-            ],
+            on_start=[activate_lifecycle_node],
         ),
     )
 

--- a/launch/sender.launch.py
+++ b/launch/sender.launch.py
@@ -36,6 +36,7 @@ from launch.event_handlers import OnProcessExit, OnProcessStart
 from launch.substitutions import FindExecutable, LaunchConfiguration
 from launch_ros.actions import LifecycleNode, Node
 
+
 def launch_setup(context, *args, **kwargs):
     # Apply context and type cast all LaunchConfiguration
     namespace = str(

--- a/scripts/activate_lifecycle
+++ b/scripts/activate_lifecycle
@@ -54,16 +54,24 @@ def main(args=None):
         ChangeState,
         f'/{arg.namespace}/'
         f'{arg.node}/change_state')
-    if not cli.wait_for_service(timeout_sec=arg.timeout):
-        node.get_logger().error('Lifecycle service not available.')
+
+    available = False
+    for i in range(arg.transition_attempts):
+        if cli.wait_for_service(timeout_sec=arg.timeout):
+            available = True
+            break
+        node.get_logger().error(
+            f'Lifecycle service not available. Trying again in {arg.timeout}...')
+    if not available:
+        node.get_logger().error(
+            f'Lifecycle service not available after {arg.transition_attempts}')
         return
 
-    retry_count = int(arg.transition_attempts)
     req = ChangeState.Request()
 
     if arg.auto_configure:
         req.transition.id = Transition.TRANSITION_CONFIGURE
-        for i in range(retry_count):
+        for i in range(arg.transition_attempts):
             future = cli.call_async(req)
             rclpy.spin_until_future_complete(node, future)
             if future.result() and future.result().success:
@@ -75,7 +83,7 @@ def main(args=None):
 
     if arg.auto_activate:
         req.transition.id = Transition.TRANSITION_ACTIVATE
-        for i in range(retry_count):
+        for i in range(arg.transition_attempts):
             future = cli.call_async(req)
             rclpy.spin_until_future_complete(node, future)
             if future.result() and future.result().success:

--- a/scripts/activate_lifecycle
+++ b/scripts/activate_lifecycle
@@ -1,4 +1,31 @@
 #!/usr/bin/env python3
+# Software License Agreement (BSD)
+#
+# @author    Luis Camero <lcamero@clearpathrobotics.com>
+# @copyright (c) 2025, Clearpath Robotics, Inc., All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of Clearpath Robotics nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
 import rclpy

--- a/scripts/activate_lifecycle
+++ b/scripts/activate_lifecycle
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+import argparse
+import rclpy
+import time
+
+from lifecycle_msgs.msg import Transition
+from lifecycle_msgs.srv import ChangeState
+
+
+def main(args=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--namespace', type=str, default='')
+    parser.add_argument('--node', type=str, default='node_name')
+    parser.add_argument('--auto_configure', type=bool, default=True)
+    parser.add_argument('--auto_activate', type=bool, default=True)
+    parser.add_argument('--timeout', type=float, default=5.0)
+    parser.add_argument('--transition_attempts', type=int, default=3)
+    arg, _ = parser.parse_known_args(args=args)
+
+    print(arg)
+
+    rclpy.init()
+    node = rclpy.create_node(f'activate_{arg.node}')
+
+    cli = node.create_client(
+        ChangeState,
+        f'/{arg.namespace}/'
+        f'{arg.node}/change_state')
+    if not cli.wait_for_service(timeout_sec=arg.timeout):
+        node.get_logger().error('Lifecycle service not available.')
+        return
+
+    retry_count = int(arg.transition_attempts)
+    req = ChangeState.Request()
+
+    if arg.auto_configure:
+        req.transition.id = Transition.TRANSITION_CONFIGURE
+        for i in range(retry_count):
+            future = cli.call_async(req)
+            rclpy.spin_until_future_complete(node, future)
+            if future.result() and future.result().success:
+                node.get_logger().info('Lifecycle node configured successfully.')
+                break
+            else:
+                node.get_logger().warn(f'Activation attempt {i+1} failed. Retrying...')
+                time.sleep(arg.timeout)
+
+    if arg.auto_activate:
+        req.transition.id = Transition.TRANSITION_ACTIVATE
+        for i in range(retry_count):
+            future = cli.call_async(req)
+            rclpy.spin_until_future_complete(node, future)
+            if future.result() and future.result().success:
+                node.get_logger().info('Lifecycle node activated successfully.')
+                break
+            else:
+                node.get_logger().warn(f'Activation attempt {i+1} failed. Retrying...')
+                time.sleep(arg.timeout)
+
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/activate_lifecycle
+++ b/scripts/activate_lifecycle
@@ -91,3 +91,4 @@ def main(args=None):
 
 if __name__ == '__main__':
     main()
+


### PR DESCRIPTION
Calling `rclpy.init()` was causing issues with other nodes. Instead of using an OpaqueFunction to call the LifecycleNode transitions, use a script. 